### PR TITLE
Remove pspermgen from memory utilization computed metrics

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,10 +2,13 @@
 
 ### Version next
 
+* Remove pspermgen from netuitive.jvm.non-heap.utilizationpercent and netuitive.jvm.totalmemory.utilizationpercent computation.
+
+### Version 2.0.0
+
 * Refresh JVM Element Details.
 * Refresh Cluster Element Details.
 * Refresh JVM Summary.
-* Remove pspermgen from netuitive.jvm.non-heap.utilizationpercent and netuitive.jvm.totalmemory.utilizationpercent computation.
 
 ### Version 1.9.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ### Version next
 
+* Remove pspermgen from netuitive.jvm.non-heap.utilizationpercent and netuitive.jvm.totalmemory.utilizationpercent computation.
+
 ### Version 1.9.0
 
 * Change elementType to elementTypes array.

--- a/analyticConfigurations/computed_metric-java.jvm.json
+++ b/analyticConfigurations/computed_metric-java.jvm.json
@@ -15,8 +15,7 @@
         "match": "netuitive.jvm.non-heap.utilizationpercent",
         "properties": {
           "expressions": [
-            "(${mempool.codecache.used}.actual + ${mempool.metaspace.used}.actual) / (${mempool.codecache.committed}.actual + ${mempool.metaspace.committed}.actual) * 100",
-            "(${mempool.codecache.used}.actual + ${mempool.pspermgen.used}.actual) / (${mempool.codecache.committed}.actual + ${mempool.pspermgen.committed}.actual) * 100"
+            "(${mempool.codecache.used}.actual + ${mempool.metaspace.used}.actual) / (${mempool.codecache.committed}.actual + ${mempool.metaspace.committed}.actual) * 100"
           ],
           "fqn": "netuitive.jvm.non-heap.utilizationpercent",
           "name": "Non-Heap Utilization Percent"
@@ -26,8 +25,7 @@
         "match": "netuitive.jvm.totalmemory.utilizationpercent",
         "properties": {
           "expressions": [
-            "(${mempool.codecache.used}.actual + ${mempool.metaspace.used}.actual + ${heap.used}.actual) / (${mempool.codecache.committed}.actual + ${mempool.metaspace.committed}.actual + ${heap.committed}.actual) * 100",
-            "(${mempool.codecache.used}.actual + ${mempool.pspermgen.used}.actual + ${heap.used}.actual) / (${mempool.codecache.committed}.actual + ${mempool.pspermgen.committed}.actual + ${heap.committed}.actual) * 100"
+            "(${mempool.codecache.used}.actual + ${mempool.metaspace.used}.actual + ${heap.used}.actual) / (${mempool.codecache.committed}.actual + ${mempool.metaspace.committed}.actual + ${heap.committed}.actual) * 100"
           ],
           "fqn": "netuitive.jvm.totalmemory.utilizationpercent",
           "name": "Total Memory Utilization Percent"


### PR DESCRIPTION
Permanent generation memory is part of the heap. Therefore, it shouldn't be part of the non-heap utilization metric computation, nor should it be be superfluously added to the total memory utilization metric computation where heap is already considered.